### PR TITLE
🐛fix wrong link for mongo 6.0.4 version on ubuntu 20.04

### DIFF
--- a/src/main/java/de/flapdoodle/embed/mongo/packageresolver/linux/UbuntuPackageResolver.java
+++ b/src/main/java/de/flapdoodle/embed/mongo/packageresolver/linux/UbuntuPackageResolver.java
@@ -304,7 +304,7 @@ public class UbuntuPackageResolver implements PackageFinder, HasPlatformMatchRul
 
 		PackageFinderRule ubuntu22x64 = PackageFinderRule.builder()
 			.match(match(BitSize.B64, CPUType.X86,
-				UbuntuVersion.Ubuntu_20_04, UbuntuVersion.Ubuntu_20_10, UbuntuVersion.Ubuntu_21_04, UbuntuVersion.Ubuntu_21_10, UbuntuVersion.Ubuntu_22_04, UbuntuVersion.Ubuntu_22_10)
+				UbuntuVersion.Ubuntu_22_04, UbuntuVersion.Ubuntu_22_10)
 				.andThen(ubuntu22xxMongoVersions))
 			.finder(UrlTemplatePackageResolver.builder()
 				.fileSet(fileSet)


### PR DESCRIPTION
A wrong downloaded archive is downloaded with Ubuntu 20.04 + mongo 6.0.4
(https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.4.tgz)
( causing ssl issue: "error while loading shared libraries: libcrypto.so.3" as ubuntu20.04 runs openssl v1 not v3)

I expect https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2004-6.0.4.tgz to be downloaded instead

# How to reproduce
On ubuntu 20.04 
Or to reproduce it on other ubuntu
Update your /etc/os-release or change the path of de.flapdoodle.os.linux.OsReleaseFiles#RELEASE_FILE_NAME

```
NAME="Ubuntu"
VERSION="20.04.4 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.4 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal

```

```
<dependency>
            <groupId>de.flapdoodle.embed</groupId>
            <artifactId>de.flapdoodle.embed.mongo.spring27x</artifactId>
            <version>4.5.1</version>
            <scope>test</scope>
        </dependency>
```

( optionnaly enable log on OS: `de.flapdoodle.os.explain` )

# Log

```
de.flapdoodle.os.common.attributes.LoggingWrapper$AttributeExtractorLookupWrapper - extractor for attribute MappedTextFile{name=/tmp/os-release, converter=OsReleaseFileConverter, charset=UTF-8}: Optional[MappedTextFileResolver]
04:06:38.303 [main] INFO  de.flapdoodle.os.common.attributes.LoggingWrapper$MatcherLookupWrapper - matcher for attribute OsReleaseFileMapEntry{key=VERSION_ID, valuePattern=\Q22.10\E.*}: Optional[de.flapdoodle.os.common.matcher.OsReleaseFileEntryMatcher@c76762]
04:06:38.304 [main] INFO  de.flapdoodle.os.common.attributes.LoggingWrapper$MatcherWrapper - value Optional[OsReleaseFile{attributes={NAME=Ubuntu, VERSION=20.04.4 LTS (Focal Fossa), ID=ubuntu, ID_LIKE=debian, PRETTY_NAME=Ubuntu 20.04.4 LTS, VERSION_ID=20.04, HOME_URL=https://www.ubuntu.com/, SUPPORT_URL=https://help.ubuntu.com/, BUG_REPORT_URL=https://bugs.launchpad.net/ubuntu/, PRIVACY_POLICY_URL=https://www.ubuntu.com/legal/terms-and-policies/privacy-policy, VERSION_CODENAME=focal, UBUNTU_CODENAME=focal}}] matches OsReleaseFileMapEntry{key=VERSION_ID, valuePattern=\Q22.10\E.*}: false
04:06:38.316 [main] INFO  de.flapdoodle.os.Platform - Platform.detect() -> Platform{operatingSystem=Linux, architecture=X86_64, distribution=Ubuntu, version=Ubuntu_20_04}
04:06:39.421 [main] INFO  de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongo - download https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-6.0.4.tgz : starting...
04:06:39.435 [main] INFO  de.flapdoodle.embed.mongo.spring.autoconfigure.EmbeddedMongo - download https://fastdl.mongodb.org/linux/mongodb-linux

```
# ERROR
This could have been ok, if mongo 6.0.4 would have not required openssl 3 at startup which is not installed on ubuntu 20.04.

